### PR TITLE
Add React-based team and management fee tracker

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,12 +1,190 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <title>Web App Template</title>
-  <link rel="stylesheet" href="style.css">
+  <meta charset="UTF-8" />
+  <title>Team & Management Fee Tracker</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
-<body>
-  <h1>Welcome to your web app</h1>
-  <script src="script.js"></script>
+<body class="bg-gray-100 p-4">
+  <div id="root"></div>
+
+  <script type="text/babel">
+    const { useState, useEffect } = React;
+    const defaultFee = 5;
+
+    function App() {
+      const [teams, setTeams] = useState(() => {
+        const saved = localStorage.getItem('teams');
+        return saved ? JSON.parse(saved) : [];
+      });
+
+      useEffect(() => {
+        localStorage.setItem('teams', JSON.stringify(teams));
+      }, [teams]);
+
+      const totalPeople = teams.reduce((sum, t) => sum + t.people.length, 0);
+      const totalFees = teams.reduce((sum, t) => {
+        return sum + t.people.reduce((ps, p) => {
+          const feePerc = p.fee !== '' && p.fee != null ? Number(p.fee) : (t.fee !== '' && t.fee != null ? Number(t.fee) : defaultFee);
+          return ps + Number(p.billable) * feePerc / 100;
+        }, 0);
+      }, 0);
+
+      const [newTeam, setNewTeam] = useState({ name: '', fee: '' });
+
+      const addTeam = e => {
+        e.preventDefault();
+        if (!newTeam.name.trim()) return;
+        setTeams([...teams, { id: Date.now(), name: newTeam.name, fee: newTeam.fee, people: [] }]);
+        setNewTeam({ name: '', fee: '' });
+      };
+
+      const deleteTeam = id => {
+        setTeams(teams.filter(t => t.id !== id));
+      };
+
+      const updateTeam = (id, updated) => {
+        setTeams(teams.map(t => t.id === id ? { ...t, ...updated } : t));
+      };
+
+      const addPerson = (teamId, person) => {
+        setTeams(teams.map(t => t.id === teamId ? { ...t, people: [...t.people, person] } : t));
+      };
+
+      const updatePerson = (teamId, personId, updated) => {
+        setTeams(teams.map(t => t.id === teamId ? { ...t, people: t.people.map(p => p.id === personId ? { ...p, ...updated } : p) } : t));
+      };
+
+      const deletePerson = (teamId, personId) => {
+        setTeams(teams.map(t => t.id === teamId ? { ...t, people: t.people.filter(p => p.id !== personId) } : t));
+      };
+
+      return (
+        <div className="max-w-3xl mx-auto">
+          <h1 className="text-2xl font-bold mb-4">Team &amp; Management Fee Tracker</h1>
+          <div className="mb-6 p-4 bg-white rounded shadow">
+            <p>Total People Managed: <span className="font-semibold">{totalPeople}</span></p>
+            <p>Total Fee Sum: <span className="font-semibold">${totalFees.toFixed(2)}</span></p>
+          </div>
+
+          <form onSubmit={addTeam} className="mb-8 bg-white p-4 rounded shadow">
+            <h2 className="text-xl font-semibold mb-2">Add Team</h2>
+            <div className="flex flex-col sm:flex-row gap-2">
+              <input className="border p-2 flex-1" placeholder="Team Name" value={newTeam.name} onChange={e => setNewTeam({ ...newTeam, name: e.target.value })} />
+              <input className="border p-2 w-32" type="number" min="0" placeholder={`Fee % (default ${defaultFee})`} value={newTeam.fee} onChange={e => setNewTeam({ ...newTeam, fee: e.target.value })} />
+              <button className="bg-blue-500 text-white px-4 py-2 rounded">Add</button>
+            </div>
+          </form>
+
+          {teams.map(team => (
+            <Team
+              key={team.id}
+              team={team}
+              defaultFee={defaultFee}
+              onDelete={() => deleteTeam(team.id)}
+              onUpdate={updated => updateTeam(team.id, updated)}
+              onAddPerson={person => addPerson(team.id, person)}
+              onUpdatePerson={(pid, upd) => updatePerson(team.id, pid, upd)}
+              onDeletePerson={pid => deletePerson(team.id, pid)}
+            />
+          ))}
+        </div>
+      );
+    }
+
+    function Team({ team, defaultFee, onDelete, onUpdate, onAddPerson, onUpdatePerson, onDeletePerson }) {
+      const [editing, setEditing] = useState(false);
+      const [form, setForm] = useState({ name: team.name, fee: team.fee ?? '' });
+      const [personForm, setPersonForm] = useState({ name: '', billable: '', fee: '' });
+      const [editingPersonId, setEditingPersonId] = useState(null);
+      const [editPersonForm, setEditPersonForm] = useState({ name: '', billable: '', fee: '' });
+
+      const submitEdit = e => {
+        e.preventDefault();
+        onUpdate({ name: form.name, fee: form.fee });
+        setEditing(false);
+      };
+
+      const submitPerson = e => {
+        e.preventDefault();
+        if (!personForm.name.trim()) return;
+        onAddPerson({ id: Date.now(), ...personForm });
+        setPersonForm({ name: '', billable: '', fee: '' });
+      };
+
+      const submitPersonEdit = e => {
+        e.preventDefault();
+        onUpdatePerson(editingPersonId, editPersonForm);
+        setEditingPersonId(null);
+      };
+
+      return (
+        <div className="mb-8 bg-white p-4 rounded shadow">
+          {editing ? (
+            <form onSubmit={submitEdit} className="mb-4 flex flex-col sm:flex-row gap-2">
+              <input className="border p-2 flex-1" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} />
+              <input className="border p-2 w-32" type="number" min="0" value={form.fee} onChange={e => setForm({ ...form, fee: e.target.value })} placeholder={`Fee % (default ${defaultFee})`} />
+              <button className="bg-green-500 text-white px-4 py-2 rounded">Save</button>
+              <button type="button" className="bg-gray-300 px-4 py-2 rounded" onClick={() => setEditing(false)}>Cancel</button>
+            </form>
+          ) : (
+            <div className="flex justify-between items-center mb-4">
+              <div>
+                <h2 className="text-xl font-semibold">{team.name}</h2>
+                <p className="text-sm text-gray-600">Fee %: {team.fee !== '' && team.fee != null ? team.fee : `${defaultFee} (default)`}</p>
+              </div>
+              <div className="space-x-2">
+                <button className="px-2 py-1 bg-yellow-400 rounded" onClick={() => setEditing(true)}>Edit</button>
+                <button className="px-2 py-1 bg-red-500 text-white rounded" onClick={onDelete}>Delete</button>
+              </div>
+            </div>
+          )}
+
+          <ul className="mb-4">
+            {team.people.map(p => {
+              const feePerc = p.fee !== '' && p.fee != null ? Number(p.fee) : (team.fee !== '' && team.fee != null ? Number(team.fee) : defaultFee);
+              const feeAmount = Number(p.billable) * feePerc / 100;
+              return (
+                <li key={p.id} className="border-b py-2">
+                  {editingPersonId === p.id ? (
+                    <form onSubmit={submitPersonEdit} className="flex flex-col sm:flex-row gap-2">
+                      <input className="border p-2 flex-1" value={editPersonForm.name} onChange={e => setEditPersonForm({ ...editPersonForm, name: e.target.value })} />
+                      <input className="border p-2 w-32" type="number" min="0" value={editPersonForm.billable} onChange={e => setEditPersonForm({ ...editPersonForm, billable: e.target.value })} placeholder="Billable" />
+                      <input className="border p-2 w-28" type="number" min="0" value={editPersonForm.fee} onChange={e => setEditPersonForm({ ...editPersonForm, fee: e.target.value })} placeholder={`Fee %`} />
+                      <button className="bg-green-500 text-white px-3 py-2 rounded">Save</button>
+                      <button type="button" className="bg-gray-300 px-3 py-2 rounded" onClick={() => setEditingPersonId(null)}>Cancel</button>
+                    </form>
+                  ) : (
+                    <div className="flex justify-between">
+                      <div>
+                        <p className="font-medium">{p.name}</p>
+                        <p className="text-sm text-gray-600">Billable: ${p.billable} | Fee %: {p.fee !== '' && p.fee != null ? p.fee : team.fee !== '' && team.fee != null ? team.fee : defaultFee} | Fee: ${feeAmount.toFixed(2)}</p>
+                      </div>
+                      <div className="space-x-2">
+                        <button className="px-2 py-1 bg-yellow-400 rounded" onClick={() => {setEditingPersonId(p.id); setEditPersonForm({ name: p.name, billable: p.billable, fee: p.fee ?? '' });}}>Edit</button>
+                        <button className="px-2 py-1 bg-red-500 text-white rounded" onClick={() => onDeletePerson(p.id)}>Delete</button>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+
+          <form onSubmit={submitPerson} className="flex flex-col sm:flex-row gap-2">
+            <input className="border p-2 flex-1" placeholder="Person Name" value={personForm.name} onChange={e => setPersonForm({ ...personForm, name: e.target.value })} />
+            <input className="border p-2 w-32" type="number" min="0" placeholder="Billable" value={personForm.billable} onChange={e => setPersonForm({ ...personForm, billable: e.target.value })} />
+            <input className="border p-2 w-28" type="number" min="0" placeholder={`Fee %`} value={personForm.fee} onChange={e => setPersonForm({ ...personForm, fee: e.target.value })} />
+            <button className="bg-blue-500 text-white px-4 py-2 rounded">Add Person</button>
+          </form>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
 </body>
 </html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,3 +1,0 @@
-document.addEventListener('DOMContentLoaded', () => {
-  console.log('Web app template loaded');
-});

--- a/public/style.css
+++ b/public/style.css
@@ -1,4 +1,0 @@
-body {
-  font-family: Arial, sans-serif;
-  margin: 2rem;
-}


### PR DESCRIPTION
## Summary
- Build browser-based tool to manage teams and people using React and Tailwind
- Calculate management fees from person, team, or default percentages and show totals
- Persist state in localStorage with add/edit/delete controls for teams and members

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6dcd4d08c8321827565e96a6f7a85