### PR TITLE
fix: resolve babel syntax error

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -38,15 +38,17 @@
     }
 
     function App() {
-      const [teams, setTeams] = useState<Team[]>(() => {
+      const initTeams = (): Team[] => {
         const saved = localStorage.getItem('teams');
         return saved ? JSON.parse(saved) : [];
-      });
+      };
+      const [teams, setTeams] = useState(initTeams);
 
-      const [globalFee, setGlobalFee] = useState<number>(() => {
+      const initGlobalFee = (): number => {
         const saved = localStorage.getItem('globalFee');
         return saved ? Number(saved) : 5;
-      });
+      };
+      const [globalFee, setGlobalFee] = useState(initGlobalFee);
 
       const [query, setQuery] = useState('');
       const { toast, show } = useToast();


### PR DESCRIPTION
## Summary
- Avoid Babel syntax errors by moving React state initializers into named functions.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6e43aeb808321a74c868efcedd0ac