### PR TITLE
Add team/member summary and refresh UI styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,7 +8,7 @@
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
 </head>
-<body class="bg-gray-100 p-4">
+  <body class="min-h-screen bg-gradient-to-br from-gray-100 via-blue-50 to-indigo-100 p-6">
   <div id="root"></div>
 
   <script type="text/babel" data-presets="typescript,react">
@@ -152,30 +152,58 @@
         return t.name.toLowerCase().includes(q) || t.people.some(p => p.name.toLowerCase().includes(q));
       });
 
-      return (
-        <div className="max-w-3xl mx-auto">
-          {toast && <div className="fixed top-4 right-4 bg-green-500 text-white px-4 py-2 rounded shadow">{toast}</div>}
-          <h1 className="text-2xl font-bold mb-4">Team &amp; Management Fee Tracker</h1>
-          <div className="mb-6 p-4 bg-white rounded shadow">
-            <p>Total People Managed: <span className="font-semibold">{totalPeople}</span></p>
-            <p>Total Fee Sum: <span className="font-semibold">${totalFees.toFixed(2)}</span></p>
-          </div>
+        return (
+          <div className="max-w-4xl mx-auto space-y-6">
+            {toast && (
+              <div className="fixed top-4 right-4 bg-green-500 text-white px-4 py-2 rounded shadow">
+                {toast}
+              </div>
+            )}
+            <h1 className="text-3xl font-bold mb-6 text-center text-indigo-600">
+              Team &amp; Management Fee Tracker
+            </h1>
+            <div className="p-6 bg-white/80 backdrop-blur rounded-lg shadow">
+              <h2 className="text-xl font-semibold mb-2">Summary</h2>
+              <p>Total People Managed: <span className="font-semibold">{totalPeople}</span></p>
+              <p>Total Fee Sum: <span className="font-semibold">${totalFees.toFixed(2)}</span></p>
+              <div className="mt-4">
+                <h3 className="font-semibold mb-1">Teams &amp; Members</h3>
+                {teams.length === 0 ? (
+                  <p className="text-sm text-gray-500">No teams yet</p>
+                ) : (
+                  <ul className="list-disc list-inside space-y-1">
+                    {teams.map(team => (
+                      <li key={team.id}>
+                        <span className="font-medium">{team.name}</span>
+                        {team.people.length > 0 && (
+                          <ul className="ml-4 list-disc list-inside text-sm text-gray-700 space-y-1">
+                            {team.people.map(person => (
+                              <li key={person.id}>{person.name}</li>
+                            ))}
+                          </ul>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
 
-          <div className="mb-4 bg-white p-4 rounded shadow flex items-center gap-2">
-            <label className="font-semibold">Global Default Fee %:</label>
-            <input className="border p-2 w-24" type="number" min="0" value={globalFee} onChange={e => setGlobalFee(Number(e.target.value))} />
-          </div>
+            <div className="mb-4 bg-white/80 backdrop-blur p-4 rounded shadow flex items-center gap-2">
+              <label className="font-semibold">Global Default Fee %:</label>
+              <input className="border p-2 w-24" type="number" min="0" value={globalFee} onChange={e => setGlobalFee(Number(e.target.value))} />
+            </div>
 
-          <div className="mb-4 flex flex-col sm:flex-row gap-2">
-            <input className="border p-2 flex-1" placeholder="Search..." value={query} onChange={e => setQuery(e.target.value)} />
-            <button type="button" className="border px-4 py-2 rounded bg-white" onClick={exportData}>Export</button>
-            <label className="border px-4 py-2 rounded bg-white cursor-pointer text-center">
-              Import
-              <input type="file" accept="application/json" className="hidden" onChange={importData} />
-            </label>
-          </div>
+            <div className="mb-4 flex flex-col sm:flex-row gap-2">
+              <input className="border p-2 flex-1" placeholder="Search..." value={query} onChange={e => setQuery(e.target.value)} />
+              <button type="button" className="border px-4 py-2 rounded bg-white/80 backdrop-blur" onClick={exportData}>Export</button>
+              <label className="border px-4 py-2 rounded bg-white/80 backdrop-blur cursor-pointer text-center">
+                Import
+                <input type="file" accept="application/json" className="hidden" onChange={importData} />
+              </label>
+            </div>
 
-          <form onSubmit={addTeam} className="mb-8 bg-white p-4 rounded shadow">
+            <form onSubmit={addTeam} className="mb-8 bg-white/80 backdrop-blur p-4 rounded shadow">
             <h2 className="text-xl font-semibold mb-2">Add Team</h2>
             <div className="flex flex-col sm:flex-row gap-2">
               <input className="border p-2 flex-1" placeholder="Team Name" value={newTeam.name} onChange={e => setNewTeam({ ...newTeam, name: e.target.value })} />
@@ -240,8 +268,8 @@
 
       const visiblePeople = team.people.filter(p => p.name.toLowerCase().includes(query.toLowerCase()));
 
-      return (
-        <div className="mb-8 bg-white p-4 rounded shadow">
+        return (
+          <div className="mb-8 bg-white/80 backdrop-blur p-4 rounded shadow">
           {editing ? (
             <form onSubmit={submitEdit} className="mb-4 flex flex-col sm:flex-row gap-2">
               <input className="border p-2 flex-1" value={form.name} onChange={e => setForm({ ...form, name: e.target.value })} />


### PR DESCRIPTION
## Summary
- list all teams and members in summary section
- apply gradient background and softer cards for improved aesthetics

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b6facf03148321bdc1231db5ccd498