### PR TITLE
Compute global fee from individual fees

### DIFF
--- a/team-fee-tracker/app.js
+++ b/team-fee-tracker/app.js
@@ -258,12 +258,13 @@ function SummaryPanel({ teams, people, globalFee }) {
 function App() {
   const [teams, setTeams] = useState([]);
   const [people, setPeople] = useState([]);
-  const [globalFee] = useState(() => {
-    const g = parseFloat(localStorage.getItem('globalFee'));
-    return !isNaN(g) ? g : 5;
-  });
   const [view, setView] = useState('teams');
   const [selectedTeamId, setSelectedTeamId] = useState('');
+
+  const globalFee = people.reduce(
+    (sum, p) => sum + (typeof p.fee === 'number' ? p.fee : 0),
+    0
+  );
 
   useEffect(() => {
     const t = JSON.parse(localStorage.getItem('teams') || '[]');


### PR DESCRIPTION
## Summary
- derive global fee by summing individual person fees
- remove unused global fee local storage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ff962d0883219901a5167141da96